### PR TITLE
feat: 마일리지 적립 내역 페이지 레이아웃 완성 #20

### DIFF
--- a/src/pages/users/mileage/mileageDetail.css
+++ b/src/pages/users/mileage/mileageDetail.css
@@ -1,3 +1,15 @@
+/* global css */
+* {
+    outline: 1px solid red;
+}
+
+.h5 {
+    font-size: 1.4rem;
+    line-height: 2.1rem;
+    font-weight: 500;
+}
+
+/* contents */
 .contents {
     padding: 16px 24px;
     gap: 12px;
@@ -5,32 +17,27 @@
     flex-direction: column;
 }
 
+/* Notice */
 .notice {
     width: 100%;
 }
 
 .notice__header,
-.notice__item {
-    width: 100%;
+.notice__row {
     height: 56px;
-
     display: flex;
-    align-items: center;
-    flex: 1 0 0;
     border-bottom: 1px solid var(--gray-05);
 }
 
 .notice__title {
-    height: 100%;
+    flex-grow: 1;
     padding: 0 10px;
-    flex: 1 0 0;
     display: flex;
     align-items: center;
 }
 
 .notice__registration-date {
     width: 140px;
-    height: 100%;
     padding: 0 10px;
     display: flex;
     align-items: center;
@@ -38,12 +45,12 @@
 
 .notice__mileage {
     width: 200px;
-    height: 100%;
     padding: 0 10px;
     display: flex;
     align-items: center;
 }
 
+/* Pagination */
 .pagination {
     display: flex;
     justify-content: flex-end;

--- a/src/pages/users/mileage/mileageDetail.html
+++ b/src/pages/users/mileage/mileageDetail.html
@@ -88,31 +88,31 @@
       <div class="contents">
         <h1 class="title">마일리지 > 마일리지 적립목록</h1>
         <h2>마일리지 적립목록(12)</h2>
-        <div class="notice">
-          <div class="notice__header">
-            <h5 class="notice__title">제목</h5>
-            <h5 class="notice__registration-date">등록일</h5>
-            <h5 class="notice__mileage">마일리지</h5>
-          </div>
 
-          <div class="notice__list">
-            <div class="notice__item">
-              <h5 class="notice__title">제목입니다.</h5>
-              <h5 class="notice__registration-date">2024.02.02</h5>
-              <h5 class="notice__mileage">2</h5>
-            </div>
-            <div class="notice__item">
-              <h5 class="notice__title">제목입니다.</h5>
-              <h5 class="notice__registration-date">2024.02.02</h5>
-              <h5 class="notice__mileage">2</h5>
-            </div>
-            <div class="notice__item">
-              <h5 class="notice__title">제목입니다.</h5>
-              <h5 class="notice__registration-date">2024.02.02</h5>
-              <h5 class="notice__mileage">2</h5>
-            </div>
-          </div>
-        </div>
+        <ul class="notice h5">
+          <li class="notice__header">
+            <div class="notice__title">제목</div>
+            <div class="notice__registration-date">등록일</div>
+            <div class="notice__mileage">마일리지</div>
+          </li>
+
+          <li class="notice__row">
+            <div class="notice__title">제목입니다.</div>
+            <div class="notice__registration-date">2024.02.02</div>
+            <div class="notice__mileage">2</div>
+          </li>
+          <li class="notice__row">
+            <div class="notice__title">제목입니다.</div>
+            <div class="notice__registration-date">2024.02.02</div>
+            <div class="notice__mileage">2</div>
+          </li>
+          <li class="notice__row">
+            <div class="notice__title">제목입니다.</div>
+            <div class="notice__registration-date">2024.02.02</div>
+            <div class="notice__mileage">2</div>
+          </li>
+        </ul>
+
         <div class="pagination">
           <a href="#">&laquo;</a>
           <a href="#">1</a>


### PR DESCRIPTION
## [사용자][마일리지 페이지] 상세 페이지 레이아웃 작성
### 구현 내용
- [x] 상세페이지 전체 레이아웃 수정
- [x] 상세페이지 테이블 스타일 수정
---
### 상세 내용
1. 피그마 디자인 가이드라인 참고해, 마일리지 상세 페이지에 대한 레이아웃을 수정합니다.
2. 마일리지 적립 내역에 대한 테이블을 `div`태그에서 `ul li`태그로 수정합니다.
---
### 추가 내용
- 브랜치명: `feat/user/mileage-detail/#20`